### PR TITLE
Update CMake script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,44 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.6)
+
 project(bce4)
 
-SET(CMAKE_CXX_FLAGS "-s -Wall -march=native -fopenmp -fno-exceptions -std=c++14")
-SET(CMAKE_LINKER_FLAGS "-s -Wall -march=native -fopenmp -fno-exceptions -std=c++14")
+option(divsufsort_STATIC "Prefer static divsufsort" ON)
+option(USE_OPENMP "Use OpenMP if available" ON)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+include(CheckCXXCompilerFlag)
+
+function(add_cxx_compiler_flags var flags)
+  foreach(flag ${flags})
+    string(REGEX REPLACE "[^a-zA-Z0-9]" "_" flag_var "CXXFLAG_${flag}")
+    check_cxx_compiler_flag("${flag}" ${flag_var})
+    if(${flag_var})
+      set(${var} "${${var}} ${flag}")
+    endif()
+    unset(flag_var)
+  endforeach()
+  set(${var} "${${var}}" PARENT_SCOPE)
+endfunction()
+
+add_cxx_compiler_flags(CMAKE_CXX_FLAGS "-std=c++14;-Wall;-pedantic;-march=native;-fno-exceptions")
+if (WIN32)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+endif()
+
+find_package(divsufsort REQUIRED)
+include_directories(${divsufsort_INCLUDE_DIRS})
+add_definitions(${divsufsort_DEFINITIONS})
+
+if(USE_OPENMP)
+  find_package(OpenMP)
+  if(OPENMP_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  endif()
+endif()
 
 add_executable(bce bce.cpp)
 
-target_link_libraries(bce divsufsort pthread)
+target_link_libraries(bce ${divsufsort_LIBRARIES} pthread)
 
 install(TARGETS bce RUNTIME DESTINATION bin)

--- a/bce.cpp
+++ b/bce.cpp
@@ -79,7 +79,7 @@ class Rank {
     inline uint32_t get(uint32_t index) const  {
       auto rank = rank_[index / 32] & (-1llu >> (32 - index % 32));
       return rank + __cnt(rank >> 32);
-    };
+    }
 
     void set(uint32_t _x, uint32_t value) {
       uint64_t n = value - get<1>(_x);
@@ -150,7 +150,7 @@ class Rank {
 template<>
 uint32_t Rank::get<0>(uint32_t index) const  {
   return index - get<1>(index);
-};
+}
 
 /*********************************
  *  The pArray                   *
@@ -1387,7 +1387,7 @@ int main(int argc, char** argv) {
 
       auto end = std::chrono::high_resolution_clock::now();
       std::chrono::duration<double> duration = end - start;
-      printf("Decompressed from %" PRIu64 " B -> %zu B in %.1f s\n",
+      printf("Decompressed from %zu B -> %zu B in %.1f s\n",
             size, data.size(), duration.count());
 
       std::ofstream file(std::string(argv[2]), std::ios::binary | std::ios::trunc);

--- a/bce.cpp
+++ b/bce.cpp
@@ -997,7 +997,9 @@ class bytewise {
           ranks[7].get<0>(n)
         };
 
+#ifdef _OPENMP
         #pragma omp parallel for
+#endif
         for (uint32_t a = 0; a < n; a += s) {
           std::array<uint32_t, 256> D;
           D.fill(0);
@@ -1180,7 +1182,9 @@ class BCE : private policy_unbwt {
       do {
         again = false;
 
+#ifdef _OPENMP
         #pragma omp parallel for
+#endif
         for (int i = 0; i < 8; ++i) {
           uint32_t local_state = 0;
           std::array<uint32_t, 2> offset = {0, 0};

--- a/cmake/Finddivsufsort.cmake
+++ b/cmake/Finddivsufsort.cmake
@@ -1,0 +1,112 @@
+#.rst:
+# Finddivsufsort
+# --------------
+#
+# Find divsufsort library
+#
+# This will define the following variables::
+#
+#   divsufsort_FOUND        - True if library found
+#   divsufsort_INCLUDE_DIRS - Locations of include files
+#   divsufsort_LIBRARIES    - Libraries for divsufsort
+#   divsufsort_DEFINITIONS  - Defines to use, if any
+#   divsufsort_VERSION      - Version of library found, if available
+#
+# and the :prop_tgt:`IMPORTED` target::
+#
+#   divsufsort::divsufsort
+#
+# These variables may be set before use::
+#
+#   divsufsort_ROOT_DIR     - Look for library here
+#   divsufsort_STATIC       - If true, prefer static library
+
+#=============================================================================
+# Copyright (c) 2016 Joergen Ibsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#=============================================================================
+
+if(divsufsort_STATIC)
+  set(_divsufsort_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  if(WIN32)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  endif()
+endif()
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_divsufsort QUIET libdivsufsort)
+
+find_path(divsufsort_INCLUDE_DIR
+  NAMES divsufsort.h
+  HINTS
+    "${divsufsort_ROOT_DIR}/include"
+    ${PC_divsufsort_INCLUDEDIR}
+    ${PC_divsufsort_INCLUDE_DIRS}
+  DOC "The divsufsort include directory"
+)
+mark_as_advanced(divsufsort_INCLUDE_DIR)
+
+find_library(divsufsort_LIBRARY
+  NAMES divsufsort
+  HINTS
+    "${divsufsort_ROOT_DIR}/lib"
+    ${PC_divsufsort_LIBDIR}
+    ${PC_divsufsort_LIBRARY_DIRS}
+  PATH_SUFFIXES
+    Release
+    Debug
+  DOC "The divsufsort library"
+)
+mark_as_advanced(divsufsort_LIBRARY)
+
+set(divsufsort_VERSION ${PC_divsufsort_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(divsufsort
+  REQUIRED_VARS
+    divsufsort_LIBRARY
+    divsufsort_INCLUDE_DIR
+  VERSION_VAR divsufsort_VERSION
+)
+
+# Workaround for older CMake without FOUND_VAR
+set(divsufsort_FOUND ${DIVSUFSORT_FOUND})
+
+if(divsufsort_FOUND)
+  set(divsufsort_INCLUDE_DIRS "${divsufsort_INCLUDE_DIR}")
+  set(divsufsort_LIBRARIES "${divsufsort_LIBRARY}")
+  set(divsufsort_DEFINITIONS ${PC_divsufsort_CFLAGS_OTHER})
+
+  if(NOT TARGET divsufsort::divsufsort)
+    add_library(divsufsort::divsufsort UNKNOWN IMPORTED)
+    set_target_properties(divsufsort::divsufsort PROPERTIES
+      IMPORTED_LOCATION "${divsufsort_LIBRARY}"
+      INTERFACE_COMPILE_OPTIONS "${PC_divsufsort_CFLAGS_OTHER}"
+      INTERFACE_INCLUDE_DIRECTORIES "${divsufsort_INCLUDE_DIR}"
+  )
+  endif()
+endif()
+
+if(divsufsort_STATIC)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_divsufsort_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+  unset(_divsufsort_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
+endif()


### PR DESCRIPTION
I don't know if it has any interest, but I made an attempt at updating the CMake script. Changes include:
- Find module for libdivsufsort (use `divsufsort_ROOT_DIR` to supply a path if needed)
- Option to enable OpenMP (and check if available)

If you prefer to keep the CMake script simple, feel free to just grab the changes from 6386aca, which fix a few warnings.
