### PR TITLE
Add missing include and link to libm.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(bce bce.cpp)
 
 target_link_libraries(bce ${divsufsort_LIBRARIES})
 if(NOT MSVC)
-  target_link_libraries(bce pthread)
+  target_link_libraries(bce pthread m)
 endif()
 
 install(TARGETS bce RUNTIME DESTINATION bin)

--- a/bce.cpp
+++ b/bce.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cassert>
 #include <cinttypes>
+#include <cmath>
 
 #include <chrono>
 #include <fstream>


### PR DESCRIPTION
Without this, the log function is undefined at least on Fedora 24 with glibc 2.23.1.
